### PR TITLE
.gitignore: add .bak and .sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,9 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Text backup files
+*.bak
+
+# Database
+*.sqlite3


### PR DESCRIPTION
Ignore backup (*.bak) and SQLite database (*.sqlite3) files to prevent 
accidental commits of local or temporary artifacts. This keeps the repo 
clean and avoids storing environment-specific data.
